### PR TITLE
Fix JSON parsing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "async": "^0.9.0",
     "body-parser": "^1.10.1",
     "express": "~4.10.0",
-    "singularity-client": "0.0.2"
+    "singularity-client": "~0.0.2"
   },
   "engines": {
     "node": ">=0.10"

--- a/queequeg.js
+++ b/queequeg.js
@@ -41,7 +41,7 @@ app.post(hookPathPrefix + '/:hook', function (req, res) {
     console.log('------------------------------------------------------------------------')
     console.log('-- Callback for %s', type);
     console.log('--');
-    console.log(JSON.stringify(JSON.parse(req.body), null, 2));
+    console.log(JSON.stringify(req.body, null, 2));
     console.log('------------------------------------------------------------------------');
 
     res.sendStatus(200);


### PR DESCRIPTION
I discovered a JSON parsing bug in my fork. Pushing it back upstream.

Also allowing newer releases of `singularity-client` (and published `v0.0.2`, `v0.0.3` and `v0.0.4` to the public registry: https://registry.npmjs.org/singularity-client).
