### PR TITLE
Switch default singularity base url to a blank string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOST?=localhost
 PORT?=3000
 SINGULARITY_HOST?=localhost
 SINGULARITY_PORT?=7099
-SINGULARITY_BASE?=/singularity
+SINGULARITY_BASE?=''
 
 usage :
 	@echo ''

--- a/queequeg.js
+++ b/queequeg.js
@@ -1,19 +1,28 @@
 var http = require('http'),
-    util = require('util'),
+    url = require('url'),
     express = require('express'),
     bodyParser = require('body-parser'),
     async = require('async'),
     Singularity = require('singularity-client');
 
+function formatUrl(hostname, port, pathname) {
+    return url.format({
+        protocol: "http",
+        hostname: hostname,
+        pathname: pathname,
+        port: port
+    });
+}
+
 var port = process.env.PORT || 3000,
     host = process.env.HOST || 'localhost',
-    serverBaseUrl = util.format("http://%s:%s", host, port),
+    singularityPort = process.env.SINGULARITY_PORT || 7099,
+    singularityHost = process.env.SINGULARITY_HOST || 'localhost',
+    singularityBase = process.env.SINGULARITY_BASE || '',
+    serverBaseUrl = formatUrl(host, port),
     hookPathPrefix = "/webhook",
     hookBaseUrl = serverBaseUrl + hookPathPrefix,
-    singularityPort = process.env.SINGULARITY_PORT || 7099,
-    singularityHost = process.env.SINGULARITY_HOST || host,
-    singularityBase = process.env.SINGULARITY_BASE || '/singularity',
-    singularityUrl = util.format("http://%s:%s%s", singularityHost, singularityPort, singularityBase);
+    singularityUrl = formatUrl(singularityHost, singularityPort, singularityBase);
 
 var singularity = new Singularity({
     singularity: {


### PR DESCRIPTION
`url.format` properly handles empty strings as paths allowing us to simply switch the default `SINGULARITY_BASE`.
